### PR TITLE
Add setting player count in bot activity

### DIFF
--- a/mta/discord-events/events.lua
+++ b/mta/discord-events/events.lua
@@ -13,11 +13,20 @@ function getPlayerName(player)
     return player.name:monochrome()
 end
 
+function sendPlayerCount(correction)
+    correction = correction or 0
+    local player_count = getPlayerCount() + correction
+    local max_players = getMaxPlayers()
+    exports.discord:send("server.player_count", { player_count = player_count, max_players = max_players })
+end
+addEventHandler("onDiscordChannelBound", root, sendPlayerCount)
+
 addEvent("onDiscordUserCommand")
 
 addEventHandler("onPlayerJoin", root,
     function ()
         exports.discord:send("player.join", { player = getPlayerName(source) })
+        sendPlayerCount()
     end
 )
 
@@ -46,6 +55,7 @@ addEventHandler("onPlayerQuit", root,
         else
             exports.discord:send("player.quit", { player = playerName, type = quitType, reason = reason })
         end
+        sendPlayerCount(-1)
     end
 )
 

--- a/mta/discord/discord.lua
+++ b/mta/discord/discord.lua
@@ -1,5 +1,6 @@
 
 addEvent("onDiscordPacket")
+addEvent("onDiscordChannelBound")
 
 local socket = false
 
@@ -92,6 +93,7 @@ function handleSelectChannelPacket(socket, payload)
             outputDebugString("[Discord] Bot isn't ready")
         else
             outputDebugString("[Discord] Channel has been bound")
+            triggerEvent("onDiscordChannelBound", resourceRoot)
 
             if not socket.bindmessage then
                 socket:write(table.json {

--- a/src/library/Bot.js
+++ b/src/library/Bot.js
@@ -48,6 +48,14 @@ class Bot extends EventEmitter {
         return this.connected;
     }
 
+    setActivity(status) {
+        if (!this.connected || !this.channel) {
+            return Promise.reject(new Error("Bot is offline or not in your guild or didn't find the specified channel"));
+        }
+
+        return this.client.user.setActivity(status);
+    }
+
     sendMessage(message) {
         if (!this.connected || !this.channel) {
             return Promise.reject(new Error("Bot is offline or not in your guild or didn't find the specified channel"));

--- a/src/library/PacketManager.js
+++ b/src/library/PacketManager.js
@@ -8,6 +8,7 @@ const ChatConfirmHandler    = require("./handler/ChatConfirmHandler");
 const PlayerEventHandler    = require("./handler/PlayerEventHandler");
 const MapManagerHandler     = require("./handler/MapManagerHandler");
 const WebradioHandler       = require("./handler/WebradioHandler");
+const ServerStatusHandler   = require("./handler/ServerStatusHandler");
 
 class PacketManager {
     constructor() {
@@ -21,6 +22,7 @@ class PacketManager {
         this.register(new PlayerEventHandler());
         this.register(new MapManagerHandler());
         this.register(new WebradioHandler());
+        this.register(new ServerStatusHandler());
     }
 
     /**

--- a/src/library/handler/ServerStatusHandler.js
+++ b/src/library/handler/ServerStatusHandler.js
@@ -1,0 +1,19 @@
+"use strict";
+
+const Handler = require("./Handler");
+
+class ServerStatusHandler extends Handler {
+    constructor() {
+        super();
+
+        this.types.add("server.player_count");
+    }
+
+    execute(bot, session, type, payload) {
+        if (type == "server.player_count") {
+            bot.setActivity(`${payload.player_count}/${payload.max_players}`);
+        }
+    }
+}
+
+module.exports = ServerStatusHandler;


### PR DESCRIPTION
This feature will print out number of players on the MTA server in discord bot's activity/description.
It uses the activity `Playing <game_name>`, setting the game name string to `<players-on-server>/<max-players>`.

Examples:
(english) `Playing 7/32`
![image](https://user-images.githubusercontent.com/5197581/108348792-83a35880-71e2-11eb-8149-c4156a85d918.png)

(polish) `W grze 1/32`
![image](https://user-images.githubusercontent.com/5197581/108337273-3bca0480-71d5-11eb-8392-596ee5d8c715.png)
